### PR TITLE
feat: Ajouter module Boîte à Stratégies Anti-Craving

### DIFF
--- a/client/src/components/strategies-box.tsx
+++ b/client/src/components/strategies-box.tsx
@@ -1,0 +1,302 @@
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
+import type { InsertAntiCravingStrategy } from "@shared/schema";
+
+const contexts = [
+  { key: 'leisure', label: 'Pendant mes loisirs' },
+  { key: 'home', label: 'Au domicile' },
+  { key: 'work', label: 'Au travail / lieu de soin' }
+];
+
+const effortLevels = [
+  { value: 'faible', label: 'Faible' },
+  { value: 'modéré', label: 'Modéré' },
+  { value: 'intense', label: 'Intense' }
+];
+
+interface StrategyRow {
+  id: string;
+  context: string;
+  exercise: string;
+  effort: string;
+  duration: number;
+  cravingBefore: number;
+  cravingAfter: number;
+}
+
+interface StrategiesBoxProps {
+  userId: string;
+  onSuccess?: () => void;
+}
+
+export function StrategiesBox({ userId, onSuccess }: StrategiesBoxProps) {
+  const [strategies, setStrategies] = useState<StrategyRow[]>([
+    {
+      id: 'default',
+      context: 'leisure',
+      exercise: '',
+      effort: 'modéré',
+      duration: 10,
+      cravingBefore: 5,
+      cravingAfter: 3
+    }
+  ]);
+
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  const saveStrategiesMutation = useMutation({
+    mutationFn: async (data: InsertAntiCravingStrategy[]) => {
+      return await apiRequest("POST", "/api/strategies", { strategies: data });
+    },
+    onSuccess: () => {
+      toast({
+        title: "Stratégies sauvegardées",
+        description: "Vos stratégies anti-craving ont été enregistrées avec succès.",
+      });
+      queryClient.invalidateQueries({ queryKey: ["/api/strategies", userId] });
+      onSuccess?.();
+    },
+    onError: (error) => {
+      toast({
+        title: "Erreur",
+        description: "Impossible de sauvegarder les stratégies. Veuillez réessayer.",
+        variant: "destructive",
+      });
+      console.error("Error saving strategies:", error);
+    },
+  });
+
+  const addRow = () => {
+    const newRow: StrategyRow = {
+      id: Date.now().toString(),
+      context: 'leisure',
+      exercise: '',
+      effort: 'modéré',
+      duration: 10,
+      cravingBefore: 5,
+      cravingAfter: 3
+    };
+    setStrategies([...strategies, newRow]);
+  };
+
+  const updateStrategy = (id: string, field: keyof StrategyRow, value: any) => {
+    setStrategies(strategies.map(strategy => 
+      strategy.id === id ? { ...strategy, [field]: value } : strategy
+    ));
+  };
+
+  const removeRow = (id: string) => {
+    if (strategies.length > 1) {
+      setStrategies(strategies.filter(strategy => strategy.id !== id));
+    }
+  };
+
+  const handleSave = () => {
+    const validStrategies = strategies
+      .filter(strategy => strategy.exercise.trim())
+      .map(strategy => ({
+        userId,
+        context: strategy.context,
+        exercise: strategy.exercise,
+        effort: strategy.effort,
+        duration: strategy.duration,
+        cravingBefore: strategy.cravingBefore,
+        cravingAfter: strategy.cravingAfter
+      }));
+
+    if (validStrategies.length === 0) {
+      toast({
+        title: "Aucune stratégie",
+        description: "Veuillez remplir au moins une stratégie avant de sauvegarder.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    saveStrategiesMutation.mutate(validStrategies);
+  };
+
+  const getExampleText = (context: string) => {
+    const examples = {
+      'leisure': 'Ex: Course à pied, méditation, lecture',
+      'home': 'Ex: Ménage, yoga, cuisine créative',
+      'work': 'Ex: Pause active, respiration, étirements'
+    };
+    return examples[context as keyof typeof examples] || '';
+  };
+
+  return (
+    <Card className="shadow-material" data-testid="card-strategies-box">
+      <CardHeader>
+        <CardTitle className="flex items-center text-lg font-medium">
+          <span className="material-icons mr-2 text-primary">psychology</span>
+          Boîte à Stratégies Anti-Craving
+        </CardTitle>
+        <div className="text-sm text-muted-foreground mt-2 space-y-2">
+          <p>
+            Cet outil vous permet de découvrir et d'expérimenter différentes activités physiques ou stratégies pour réduire vos envies de fumer (cravings).
+          </p>
+          <p>
+            Vous pouvez tester plusieurs actions, noter leur durée, leur intensité et évaluer l'impact sur votre craving avant et après l'activité.
+          </p>
+          <p>
+            Avec le temps, cela vous aidera à identifier les stratégies qui vous apportent le plus de bénéfices et à construire votre propre boîte à outils anti-craving.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Table Header */}
+        <div className="overflow-x-auto">
+          <div className="min-w-[800px]">
+            {/* Headers */}
+            <div className="grid grid-cols-7 gap-2 p-2 bg-muted/50 rounded-lg text-sm font-medium">
+              <div className="text-center">Contexte</div>
+              <div className="text-center">Exercices</div>
+              <div className="text-center">Effort / Intensité</div>
+              <div className="text-center">Durée (min)</div>
+              <div className="text-center">Craving Avant</div>
+              <div className="text-center">Craving Après</div>
+              <div className="text-center">Actions</div>
+            </div>
+
+            {/* Strategy Rows */}
+            <div className="space-y-2 mt-4">
+              {strategies.map((strategy, index) => (
+                <div key={strategy.id} className="grid grid-cols-7 gap-2 p-2 border rounded-lg">
+                  {/* Context */}
+                  <div className="flex flex-col">
+                    <select
+                      value={strategy.context}
+                      onChange={(e) => updateStrategy(strategy.id, 'context', e.target.value)}
+                      className="w-full p-2 border border-input rounded text-sm bg-background"
+                      data-testid={`select-context-${index}`}
+                    >
+                      {contexts.map(context => (
+                        <option key={context.key} value={context.key}>
+                          {context.label}
+                        </option>
+                      ))}
+                    </select>
+                    <div className="text-xs text-muted-foreground mt-1 italic">
+                      {getExampleText(strategy.context)}
+                    </div>
+                  </div>
+
+                  {/* Exercise */}
+                  <div>
+                    <textarea
+                      value={strategy.exercise}
+                      onChange={(e) => updateStrategy(strategy.id, 'exercise', e.target.value)}
+                      placeholder="Décrivez votre activité/stratégie..."
+                      className="w-full p-2 border border-input rounded text-sm resize-none h-16 bg-background"
+                      data-testid={`textarea-exercise-${index}`}
+                    />
+                  </div>
+
+                  {/* Effort */}
+                  <div>
+                    <select
+                      value={strategy.effort}
+                      onChange={(e) => updateStrategy(strategy.id, 'effort', e.target.value)}
+                      className="w-full p-2 border border-input rounded text-sm bg-background"
+                      data-testid={`select-effort-${index}`}
+                    >
+                      {effortLevels.map(level => (
+                        <option key={level.value} value={level.value}>
+                          {level.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {/* Duration */}
+                  <div>
+                    <input
+                      type="number"
+                      min="1"
+                      max="180"
+                      value={strategy.duration}
+                      onChange={(e) => updateStrategy(strategy.id, 'duration', Number(e.target.value))}
+                      className="w-full p-2 border border-input rounded text-sm bg-background"
+                      data-testid={`input-duration-${index}`}
+                    />
+                  </div>
+
+                  {/* Craving Before */}
+                  <div>
+                    <select
+                      value={strategy.cravingBefore}
+                      onChange={(e) => updateStrategy(strategy.id, 'cravingBefore', Number(e.target.value))}
+                      className="w-full p-2 border border-input rounded text-sm bg-background"
+                      data-testid={`select-craving-before-${index}`}
+                    >
+                      {Array.from({length: 11}, (_, i) => (
+                        <option key={i} value={i}>{i}</option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {/* Craving After */}
+                  <div>
+                    <select
+                      value={strategy.cravingAfter}
+                      onChange={(e) => updateStrategy(strategy.id, 'cravingAfter', Number(e.target.value))}
+                      className="w-full p-2 border border-input rounded text-sm bg-background"
+                      data-testid={`select-craving-after-${index}`}
+                    >
+                      {Array.from({length: 11}, (_, i) => (
+                        <option key={i} value={i}>{i}</option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {/* Actions */}
+                  <div className="flex justify-center">
+                    {strategies.length > 1 && (
+                      <Button
+                        onClick={() => removeRow(strategy.id)}
+                        variant="outline"
+                        size="sm"
+                        className="text-destructive hover:text-destructive"
+                        data-testid={`button-remove-${index}`}
+                      >
+                        <span className="material-icons text-sm">delete</span>
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="flex flex-col sm:flex-row gap-3 justify-between pt-4">
+          <Button
+            onClick={addRow}
+            variant="outline"
+            className="flex items-center gap-2"
+            data-testid="button-add-row"
+          >
+            <span className="material-icons text-sm">add</span>
+            Ajouter une ligne
+          </Button>
+
+          <Button
+            onClick={handleSave}
+            disabled={saveStrategiesMutation.isPending}
+            className="bg-primary text-primary-foreground hover:bg-primary/90"
+            data-testid="button-save-strategies"
+          >
+            {saveStrategiesMutation.isPending ? "Sauvegarde..." : "Sauvegarder dans l'onglet Suivi"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -4,6 +4,7 @@ import { Link } from "wouter";
 import { Navigation } from "@/components/navigation";
 import { CravingEntry } from "@/components/craving-entry";
 import { BeckColumn } from "@/components/beck-column";
+import { StrategiesBox } from "@/components/strategies-box";
 import { GamificationProgress } from "@/components/gamification-progress";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -21,6 +22,7 @@ interface CravingStats {
 export default function Dashboard() {
   const [showCravingEntry, setShowCravingEntry] = useState(false);
   const [showBeckColumn, setShowBeckColumn] = useState(false);
+  const [showStrategiesBox, setShowStrategiesBox] = useState(false);
   const { toast } = useToast();
   
   // Récupérer l'utilisateur authentifié
@@ -181,7 +183,7 @@ export default function Dashboard() {
         </section>
 
         {/* Quick Actions */}
-        <section className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+        <section className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
           <Card className="shadow-material" data-testid="card-quick-craving">
             <CardHeader>
               <CardTitle className="flex items-center">
@@ -224,6 +226,28 @@ export default function Dashboard() {
               </Button>
             </CardContent>
           </Card>
+
+          <Card className="shadow-material" data-testid="card-quick-strategies">
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <span className="material-icons mr-2 text-warning">fitness_center</span>
+                Boîte à Stratégies
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground mb-4">
+                Testez et évaluez vos stratégies anti-craving
+              </p>
+              <Button 
+                onClick={() => setShowStrategiesBox(!showStrategiesBox)}
+                variant="outline"
+                className="w-full"
+                data-testid="button-toggle-strategies"
+              >
+                {showStrategiesBox ? "Masquer" : "Ouvrir Boîte à Stratégies"}
+              </Button>
+            </CardContent>
+          </Card>
         </section>
 
         {/* Conditional Forms */}
@@ -251,6 +275,21 @@ export default function Dashboard() {
                 toast({
                   title: "Analyse sauvegardée",
                   description: "Votre réflexion a été enregistrée.",
+                });
+              }}
+            />
+          </section>
+        )}
+
+        {showStrategiesBox && authenticatedUser && (
+          <section className="mb-8">
+            <StrategiesBox 
+              userId={authenticatedUser.id}
+              onSuccess={() => {
+                setShowStrategiesBox(false);
+                toast({
+                  title: "Stratégies sauvegardées",
+                  description: "Vos stratégies anti-craving ont été enregistrées dans l'onglet Suivi.",
                 });
               }}
             />

--- a/migrations/0002_anti_craving_strategies.sql
+++ b/migrations/0002_anti_craving_strategies.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS "anti_craving_strategies" (
+	"id" varchar PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" varchar NOT NULL,
+	"context" varchar NOT NULL,
+	"exercise" text NOT NULL,
+	"effort" varchar NOT NULL,
+	"duration" integer NOT NULL,
+	"craving_before" integer NOT NULL,
+	"craving_after" integer NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "anti_craving_strategies" ADD CONSTRAINT "anti_craving_strategies_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2,7 +2,7 @@
 import type { Express } from "express";
 import { storage } from "./storage.js";
 import { AuthService, requireAuth, requireAdmin } from "./auth.js";
-import { insertCravingEntrySchema, insertExerciseSessionSchema, insertBeckAnalysisSchema, insertUserSchema, insertExerciseSchema, insertPsychoEducationContentSchema } from "../shared/schema.js";
+import { insertCravingEntrySchema, insertExerciseSessionSchema, insertBeckAnalysisSchema, insertUserSchema, insertExerciseSchema, insertPsychoEducationContentSchema, insertAntiCravingStrategySchema } from "../shared/schema.js";
 import { z } from "zod";
 import { getDB } from './db.js';
 import { sql } from 'drizzle-orm';
@@ -547,6 +547,38 @@ export function registerRoutes(app: Express) {
       res.json({ message: "Quick resource pin status toggled successfully" });
     } catch (error) {
       res.status(500).json({ message: "Failed to toggle pin status" });
+    }
+  });
+
+  // ========================
+  // 🎯 ANTI-CRAVING STRATEGIES ROUTES
+  // ========================
+
+  app.post("/api/strategies", requireAuth, async (req, res) => {
+    try {
+      const userId = req.session.user!.id;
+      const { strategies } = req.body;
+      
+      if (!Array.isArray(strategies)) {
+        return res.status(400).json({ message: "Les stratégies doivent être un tableau" });
+      }
+
+      const savedStrategies = await storage.createAntiCravingStrategies(userId, strategies);
+      res.json(savedStrategies);
+    } catch (error) {
+      console.error("Error saving anti-craving strategies:", error);
+      res.status(500).json({ message: "Erreur lors de la sauvegarde des stratégies" });
+    }
+  });
+
+  app.get("/api/strategies", requireAuth, async (req, res) => {
+    try {
+      const userId = req.session.user!.id;
+      const strategies = await storage.getAntiCravingStrategies(userId);
+      res.json(strategies);
+    } catch (error) {
+      console.error("Error fetching anti-craving strategies:", error);
+      res.status(500).json({ message: "Erreur lors de la récupération des stratégies" });
     }
   });
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -10,6 +10,7 @@ import {
   userStats,
   emergencyRoutines,
   quickResources,
+  antiCravingStrategies,
   type User,
   type InsertUser,
   type Exercise,
@@ -29,6 +30,8 @@ import {
   type InsertEmergencyRoutine,
   type QuickResource,
   type InsertQuickResource,
+  type AntiCravingStrategy,
+  type InsertAntiCravingStrategy,
 } from "../shared/schema.js";
 import { randomUUID } from "crypto";
 import { eq, desc, sql, and, gte } from "drizzle-orm";
@@ -89,6 +92,10 @@ export interface IStorage {
   deleteQuickResource(resourceId: string): Promise<void>;
   getPinnedQuickResources(): Promise<QuickResource[]>;
   togglePinQuickResource(resourceId: string): Promise<void>;
+  
+  // Anti-craving strategies operations
+  createAntiCravingStrategies(userId: string, strategies: InsertAntiCravingStrategy[]): Promise<AntiCravingStrategy[]>;
+  getAntiCravingStrategies(userId: string): Promise<AntiCravingStrategy[]>;
   
   awardBadge(badge: InsertUserBadge): Promise<UserBadge>;
   checkAndAwardBadges(userId: string): Promise<UserBadge[]>;
@@ -464,6 +471,29 @@ Object.assign(DbStorage.prototype, {
     // Pour l'instant, ne rien faire car la table media n'existe pas encore
     // Dans une implémentation complète, on supprimerait le fichier de la table media
     return;
+  },
+
+  // Anti-craving strategies operations
+  async createAntiCravingStrategies(userId: string, strategies: InsertAntiCravingStrategy[]): Promise<AntiCravingStrategy[]> {
+    const strategiesWithUserId = strategies.map(strategy => ({
+      ...strategy,
+      userId
+    }));
+    
+    const result = await getDB()
+      .insert(antiCravingStrategies)
+      .values(strategiesWithUserId)
+      .returning();
+    
+    return result;
+  },
+
+  async getAntiCravingStrategies(userId: string): Promise<AntiCravingStrategy[]> {
+    return getDB()
+      .select()
+      .from(antiCravingStrategies)
+      .where(eq(antiCravingStrategies.userId, userId))
+      .orderBy(desc(antiCravingStrategies.createdAt));
   }
 });
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -191,6 +191,26 @@ export const insertQuickResourceSchema = createInsertSchema(quickResources).omit
   updatedAt: true,
 });
 
+// Anti-craving strategies table
+export const antiCravingStrategies = pgTable("anti_craving_strategies", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar("user_id").notNull().references(() => users.id, { onDelete: 'cascade' }),
+  context: varchar("context").notNull(), // 'leisure', 'home', 'work'
+  exercise: text("exercise").notNull(),
+  effort: varchar("effort").notNull(), // 'faible', 'modéré', 'intense'
+  duration: integer("duration").notNull(), // in minutes
+  cravingBefore: integer("craving_before").notNull(), // 0-10 scale
+  cravingAfter: integer("craving_after").notNull(), // 0-10 scale
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
+});
+
+export const insertAntiCravingStrategySchema = createInsertSchema(antiCravingStrategies).omit({
+  id: true,
+  createdAt: true,
+  updatedAt: true,
+});
+
 // Types
 export type User = typeof users.$inferSelect;
 export type InsertUser = z.infer<typeof insertUserSchema>;
@@ -211,3 +231,5 @@ export type EmergencyRoutine = typeof emergencyRoutines.$inferSelect;
 export type InsertEmergencyRoutine = z.infer<typeof insertEmergencyRoutineSchema>;
 export type QuickResource = typeof quickResources.$inferSelect;
 export type InsertQuickResource = z.infer<typeof insertQuickResourceSchema>;
+export type AntiCravingStrategy = typeof antiCravingStrategies.$inferSelect;
+export type InsertAntiCravingStrategy = z.infer<typeof insertAntiCravingStrategySchema>;


### PR DESCRIPTION
- Créer le composant StrategiesBox avec tableau interactif
- Ajouter les types TypeScript pour AntiCravingStrategy
- Ajouter les routes API /api/strategies (POST et GET)
- Intégrer le module dans le dashboard avec bouton d'accès
- Ajouter l'onglet Stratégies dans la page de suivi
- Créer la migration pour la table anti_craving_strategies
- Interface complète selon les spécifications (contextes, effort, durée, cravings avant/après)
- Sauvegarde automatique dans l'onglet Suivi avec analyse des résultats
- Texte explicatif et exemples pour guider l'utilisateur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Nouvelles fonctionnalités
  * Ajout de la “Boîte à Stratégies Anti-Craving” dans le tableau de bord pour saisir des stratégies (contexte, exercice, effort, durée, envie avant/après) et les enregistrer.
  * Nouvel onglet “Stratégies” dans “Suivi” affichant l’historique avec badges de contexte, détails et évolution de l’envie.

* Améliorations UX
  * Messages de confirmation/erreur lors de l’enregistrement, bouton de sauvegarde avec état de progression.
  * Exemples contextuels pour guider la saisie.
  * Affichage d’état vide lorsque aucune stratégie n’est disponible.

* Tableau de bord
  * Carte d’action rapide dédiée avec bouton pour afficher/masquer la Boîte à Stratégies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->