### PR TITLE
fix: résolution du problème d'enregistrement des stratégies anti-craving

### DIFF
--- a/client/src/pages/tracking.tsx
+++ b/client/src/pages/tracking.tsx
@@ -75,10 +75,18 @@ export default function Tracking() {
   });
 
   const { data: antiCravingStrategies, isLoading: strategiesLoading } = useQuery<AntiCravingStrategy[]>({
-    queryKey: ["/api/strategies", authenticatedUser?.id],
+    queryKey: ["/api/strategies"],
     queryFn: async () => {
-      const response = await fetch("/api/strategies");
-      if (!response.ok) throw new Error("Failed to fetch strategies");
+      const response = await fetch("/api/strategies", {
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      if (!response.ok) {
+        console.error(`Erreur API strategies: ${response.status} ${response.statusText}`);
+        throw new Error("Failed to fetch strategies");
+      }
       return response.json();
     },
     enabled: !!authenticatedUser,


### PR DESCRIPTION
- Amélioration de la gestion d'erreur dans strategies-box.tsx avec des messages détaillés
- Ajout du refetch automatique après sauvegarde pour mise à jour immédiate
- Correction de la clé de cache dans tracking.tsx pour éviter les conflits
- Ajout des credentials explicites pour maintenir la session utilisateur
- Les stratégies sont maintenant correctement sauvegardées et affichées dans l'onglet Suivi

Fixes: Impossible d'enregistrer les stratégies dans la Boîte à Stratégies Anti-Craving