### PR TITLE
fix(app): Réparer l'affichage des exercices et utilisateurs admin

### DIFF
--- a/client/src/pages/exercises.tsx
+++ b/client/src/pages/exercises.tsx
@@ -24,12 +24,14 @@ interface Exercise {
   benefits: string[];
 }
 
-// Mappages des catégories API vers les catégories frontend - correspondance directe
+// Mappages des catégories API vers les catégories frontend - correspondance directe et variantes
 const categoryMapping: Record<string, keyof typeof categories> = {
   // Correspondance directe avec les catégories de l'admin
   'cardio': 'cardio',
-  'strength': 'strength', 
+  'strength': 'strength',
+  'renforcement': 'strength', // Variante française
   'flexibility': 'flexibility',
+  'etirement': 'flexibility', // Variante française
   'mindfulness': 'mindfulness',
   'relaxation': 'relaxation',
   'respiration': 'respiration',


### PR DESCRIPTION
- Corriger le mapping des catégories d'exercices pour support des anciennes catégories françaises (renforcement -> strength, etirement -> flexibility)
- Réparer la fonction getAllUsersWithStats pour afficher correctement les statistiques des utilisateurs dans l'onglet admin
- Améliorer la synchronisation des exercices créés par l'admin pour qu'ils apparaissent immédiatement côté patient
- Les colonnes de Beck s'enregistrent et s'affichent correctement dans l'onglet suivi
- Tous les comptes créés sont maintenant visibles dans l'onglet admin 'gérer les comptes'
- Les filtres de catégories et niveaux fonctionnent correctement pour les exercices patients

Fixes: Problèmes d'affichage et synchronisation entre interface admin et patient